### PR TITLE
Feature/plain text bullets

### DIFF
--- a/docx/document.py
+++ b/docx/document.py
@@ -23,7 +23,7 @@ class Document(ElementProxy):
 
     __slots__ = ('_part', '__body')
 
-    def __init__(self, element, part, fudge_markers = True):
+    def __init__(self, element, part, fudge_markers = False):
         super(Document, self).__init__(element)
         self._part = part
         self.__body = None

--- a/docx/document.py
+++ b/docx/document.py
@@ -146,7 +146,7 @@ class Document(ElementProxy):
         # Overwrite the existing representation of the text in 
         for par,num in zip(self.paragraphs,para_nums):
             if num is None: continue
-            print(num, par.text)
+            #print(num, par.text)
             par.text = " ".join([num+")",
                                  "" if par.text is None else par.text])
 


### PR DESCRIPTION
"Fudges" plain text bullets in place of enumerated bullets. 

Currently should behave exactly the same as normal without any other intervention. To insert plain text bullets, call `document.fudge_list_markers`, which should insert the plain text bullets.

