### PR TITLE
Dev 1654 - Support for Subdocument ID

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,10 @@
 
 Release History
 ---------------
+0.4.2-rc.1 (2022-04-01)
+++++++++++++++++++
+- Adds attributes to access more information about formatting
+
 
 0.4.1 (2022-01-31)
 ++++++++++++++++++

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = "0.4.1"
+__version__ = "0.4.2-rc.1"
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/styles.py
+++ b/docx/oxml/styles.py
@@ -36,11 +36,34 @@ class CT_DocDefaults(BaseOxmlElement):
     rPrDefault = ZeroOrOne('w:rPrDefault', successors=(_tag_seq[1:]))
     pPrDefault = ZeroOrOne('w:pPrDefault', successors=())
 
+    @property
+    def rpr(self):
+        rpr_default = self.rPrDefault
+        if rpr_default is None:
+            return None
+        return rpr_default.rpr
+
+    @property
+    def ppr(self):
+        ppr_default = self.pPrDefault
+        if ppr_default is None:
+            return None
+        return ppr_default.ppr
+
+
 class CT_RPrDefault(BaseOxmlElement):
     rPr = ZeroOrOne('w:rPr', successors=())
 
+    @property
+    def rpr(self):
+        return self.rPr
+
 class CT_PPrDefault(BaseOxmlElement):
     pPr = ZeroOrOne('w:pPr', successors=())
+
+    @property
+    def ppr(self):
+        return self.pPr
 
 class CT_LatentStyles(BaseOxmlElement):
     """
@@ -143,6 +166,14 @@ class CT_Style(BaseOxmlElement):
     styleId = OptionalAttribute('w:styleId', ST_String)
     default = OptionalAttribute('w:default', ST_OnOff)
     customStyle = OptionalAttribute('w:customStyle', ST_OnOff)
+
+    @property
+    def rpr(self):
+        return self.rPr
+
+    @property
+    def ppr(self):
+        return self.pPr
 
     @property
     def basedOn_val(self):

--- a/docx/oxml/styles.py
+++ b/docx/oxml/styles.py
@@ -36,20 +36,11 @@ class CT_DocDefaults(BaseOxmlElement):
     rPrDefault = ZeroOrOne('w:rPrDefault', successors=(_tag_seq[1:]))
     pPrDefault = ZeroOrOne('w:pPrDefault', successors=())
 
-    @property
-    def rpr(self):
-        rpr_default = self.rPrDefault
-        if rpr_default is None:
-            return None
-        return self.rPrDefault.rPr
-
-
 class CT_RPrDefault(BaseOxmlElement):
     rPr = ZeroOrOne('w:rPr', successors=())
 
 class CT_PPrDefault(BaseOxmlElement):
     pPr = ZeroOrOne('w:pPr', successors=())
-
 
 class CT_LatentStyles(BaseOxmlElement):
     """
@@ -152,10 +143,6 @@ class CT_Style(BaseOxmlElement):
     styleId = OptionalAttribute('w:styleId', ST_String)
     default = OptionalAttribute('w:default', ST_OnOff)
     customStyle = OptionalAttribute('w:customStyle', ST_OnOff)
-
-    @property
-    def rpr(self):
-        return self.rPr
 
     @property
     def basedOn_val(self):

--- a/docx/oxml/styles.py
+++ b/docx/oxml/styles.py
@@ -36,11 +36,20 @@ class CT_DocDefaults(BaseOxmlElement):
     rPrDefault = ZeroOrOne('w:rPrDefault', successors=(_tag_seq[1:]))
     pPrDefault = ZeroOrOne('w:pPrDefault', successors=())
 
+    @property
+    def rpr(self):
+        rpr_default = self.rPrDefault
+        if rpr_default is None:
+            return None
+        return self.rPrDefault.rPr
+
+
 class CT_RPrDefault(BaseOxmlElement):
     rPr = ZeroOrOne('w:rPr', successors=())
 
 class CT_PPrDefault(BaseOxmlElement):
     pPr = ZeroOrOne('w:pPr', successors=())
+
 
 class CT_LatentStyles(BaseOxmlElement):
     """
@@ -143,6 +152,10 @@ class CT_Style(BaseOxmlElement):
     styleId = OptionalAttribute('w:styleId', ST_String)
     default = OptionalAttribute('w:default', ST_OnOff)
     customStyle = OptionalAttribute('w:customStyle', ST_OnOff)
+
+    @property
+    def rpr(self):
+        return self.rPr
 
     @property
     def basedOn_val(self):

--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -321,6 +321,27 @@ class CT_RPr(BaseOxmlElement):
         element = getattr(self, 'get_or_add_%s' % name)()
         element.val = value
 
+    @property
+    def b_val(self):
+        b = self.b
+        if b is None:
+            return None
+        return b.val
+
+    @property
+    def i_val(self):
+        i = self.i
+        if i is None:
+            return None
+        return i.val
+
+    @property
+    def caps_val(self):
+        caps = self.caps
+        if caps is None:
+            return None
+        return caps.val
+
 
 class CT_Underline(BaseOxmlElement):
     """

--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -337,14 +337,6 @@ class CT_RPr(BaseOxmlElement):
         else:
             return i.val
 
-    @property
-    def caps_val(self):
-        caps = self.caps
-        if caps is None:
-            return None
-        else:
-            return caps.val
-
 
 class CT_Underline(BaseOxmlElement):
     """

--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -321,6 +321,22 @@ class CT_RPr(BaseOxmlElement):
         element = getattr(self, 'get_or_add_%s' % name)()
         element.val = value
 
+    @property
+    def b_val(self):
+        b = self.b
+        if b is None:
+            return None
+        else:
+            return b.val
+
+    @property
+    def i_val(self):
+        i = self.i
+        if i is None:
+            return None
+        else:
+            return i.val
+
 
 class CT_Underline(BaseOxmlElement):
     """

--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -337,6 +337,14 @@ class CT_RPr(BaseOxmlElement):
         else:
             return i.val
 
+    @property
+    def caps_val(self):
+        caps = self.caps
+        if caps is None:
+            return None
+        else:
+            return caps.val
+
 
 class CT_Underline(BaseOxmlElement):
     """

--- a/docx/oxml/text/font.py
+++ b/docx/oxml/text/font.py
@@ -321,22 +321,6 @@ class CT_RPr(BaseOxmlElement):
         element = getattr(self, 'get_or_add_%s' % name)()
         element.val = value
 
-    @property
-    def b_val(self):
-        b = self.b
-        if b is None:
-            return None
-        else:
-            return b.val
-
-    @property
-    def i_val(self):
-        i = self.i
-        if i is None:
-            return None
-        else:
-            return i.val
-
 
 class CT_Underline(BaseOxmlElement):
     """

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -310,6 +310,10 @@ class CT_PPr(BaseOxmlElement):
         else:
             self.get_or_add_widowControl().val = value
 
+    @property
+    def sectpr(self):
+        return self.sectPr
+
 
 class CT_Spacing(BaseOxmlElement):
     """

--- a/docx/oxml/text/parfmt.py
+++ b/docx/oxml/text/parfmt.py
@@ -62,6 +62,10 @@ class CT_PPr(BaseOxmlElement):
     del _tag_seq
 
     @property
+    def rpr(self):
+        return self.rPr
+
+    @property
     def first_line_indent(self):
         """
         A |Length| value calculated from the values of `w:ind/@w:firstLine`

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -38,6 +38,7 @@ class CT_R(BaseOxmlElement):
     def _insert_rPr(self, rPr):
         self.insert(0, rPr)
         return rPr
+
     def add_dt(self, text):
         """
         Return a newly added ``<w:delText>`` element containing *text*.

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -38,7 +38,6 @@ class CT_R(BaseOxmlElement):
     def _insert_rPr(self, rPr):
         self.insert(0, rPr)
         return rPr
-
     def add_dt(self, text):
         """
         Return a newly added ``<w:delText>`` element containing *text*.

--- a/docx/oxml/text/run.py
+++ b/docx/oxml/text/run.py
@@ -38,6 +38,7 @@ class CT_R(BaseOxmlElement):
     def _insert_rPr(self, rPr):
         self.insert(0, rPr)
         return rPr
+
     def add_dt(self, text):
         """
         Return a newly added ``<w:delText>`` element containing *text*.
@@ -231,6 +232,14 @@ class CT_R(BaseOxmlElement):
     def deltext(self, text):
         self.clear_content()
         _DelRunContentAppender.append_to_run_from_text(self, text)
+
+    @property
+    def br(self):
+        br = self.xpath("./w:br")
+        if len(br) == 0:
+            return None
+        return br
+
 
 class CT_Text(BaseOxmlElement):
     """

--- a/docx/text/paragraph.py
+++ b/docx/text/paragraph.py
@@ -24,7 +24,7 @@ class Paragraph(Parented):
     """
     def __init__(self, p, parent):
         super(Paragraph, self).__init__(parent)
-        self._p = self._element = p
+        self._p = self._element = self.element = p
 
     def add_ins(self, text=None, style=None):
         i = self._p.add_i()

--- a/docx/text/parfmt.py
+++ b/docx/text/parfmt.py
@@ -23,6 +23,13 @@ class ParagraphFormat(ElementProxy):
     __slots__ = ('_tab_stops',)
 
     @property
+    def ppr(self):
+        ppr = self._element.pPr
+        if ppr is None:
+            return None
+        return ppr
+
+    @property
     def alignment(self):
         """
         A member of the :ref:`WdParagraphAlignment` enumeration specifying


### PR DESCRIPTION
# Overview
These changes were necessary to get more accurate formatting information for runs in `megapolyglot`. 

There are some reverted commits in here because I was accidentally working on master, but didn't push thankfully. Was fumbling around with git before I realized there was probably a better way to fix that mistake.
