### PR TITLE
DEV-2853: Fix all_runs method of Ins and Del

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ Release History
 ---------------
 0.4.5 ()
 ++++++++++++++++++
+- DEV-2853: fix `all_runs` methods of Ins and Del objects
 
 
 0.4.4 (2022-09-14)

--- a/docx/text/delrun.py
+++ b/docx/text/delrun.py
@@ -58,7 +58,7 @@ class Del(Parented):
 
     @property
     def all_runs(self):
-        return [Run(r, self) for r in self._d.xpath('.//w:r[not(ancestor::w:r)]')]
+        return [Run(r, self) for r in self._d.xpath('.//w:r')]
 
 
 class _Text(object):

--- a/docx/text/delrun.py
+++ b/docx/text/delrun.py
@@ -58,7 +58,7 @@ class Del(Parented):
 
     @property
     def all_runs(self):
-        return [Run(r, self) for r in self._d.xpath('.//w:r')]
+        return [Run(r, self) for r in self._d.xpath('./w:r')]
 
 
 class _Text(object):

--- a/docx/text/insrun.py
+++ b/docx/text/insrun.py
@@ -57,7 +57,7 @@ class Ins(Parented):
 
     @property
     def all_runs(self):
-        return [Run(r, self) for r in self._i.xpath('.//w:r')]
+        return [Run(r, self) for r in self._i.xpath('./w:r')]
 
 
 class _Text(object):

--- a/docx/text/insrun.py
+++ b/docx/text/insrun.py
@@ -57,7 +57,8 @@ class Ins(Parented):
 
     @property
     def all_runs(self):
-        return [Run(r, self) for r in self._i.xpath('.//w:r[not(ancestor::w:r)]')]
+        return [Run(r, self) for r in self._i.xpath('.//w:r')]
+
 
 class _Text(object):
     """


### PR DESCRIPTION
These methods are intended to grab all `w:r` child nodes of the current node, and return `Run` objects for each. The issue is that when the `w:ins` or `w:del` is child of `w:r`, the xpath operation `[not(ancestor::w:r)]` excludes all runs that have a run as an ancestor. Take the following (simplified) example of this:

```
>>> from docx.oxml.xmlchemy import OxmlElement
>>> run = OxmlElement("w:r")
>>> ins = OxmlElement("w:ins")
>>> child_run = OxmlElement("w:r")
>>> run.append(ins)
>>> ins.append(child_run)
>>> print(run.xml)
<w:r xmlns:w="http://schemas.openxmlformats.org/wordprocessingml/2006/main">
  <w:ins>
    <w:r/>
  </w:ins>
</w:r>
>>> child_run
<CT_R '<w:r>' at 0x7f2c277006d0>
>>> ins.xpath(".//w:r")
[<CT_R '<w:r>' at 0x7f2c277006d0>]
>>> ins.xpath(".//w:r[not(ancestor::w:r)]")
[]
```

The case of `w:ins` being a child of `w:r` can happen when the insert goes into e.g. a table or some other alternate content in the document.

The syntax `xpath("./w:r")` is the correct syntax here because we want to return only children of the current node `w:ins`, since we are creating `Run` objects for them that are parented by `w:ins`