### PR TITLE
DEV-3177: get children anywhere for all_runs

### DIFF
--- a/docx/text/insrun.py
+++ b/docx/text/insrun.py
@@ -57,7 +57,7 @@ class Ins(Parented):
 
     @property
     def all_runs(self):
-        return [Run(r, self) for r in self._i.xpath('./w:r')]
+        return [Run(r, self) for r in self._i.xpath('.//w:r')]
 
 
 class _Text(object):


### PR DESCRIPTION
`all_runs` as written does not get runs nested in child delete tags, use xpath spec `.//` to get runs from all descendants

This is needed for comment insertion around multiround edits