### PR TITLE
v0.4.6 - Wrap int() call in float() for size classes to avoid ValueError

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -2,6 +2,11 @@
 
 Release History
 ---------------
+
+0.4.6 ()
+++++++++++++++++++
+
+
 0.4.5 (2023-02-06)
 ++++++++++++++++++
 - DEV-2853: fix `all_runs` methods of Ins and Del objects

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -5,7 +5,8 @@ Release History
 
 0.4.6 ()
 ++++++++++++++++++
-
+- DEV-3195: wrap int() call in float() so we can read float vals of size attrs
+    in e.g. w:spacing tags
 
 0.4.5 (2023-02-06)
 ++++++++++++++++++

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = "0.4.5"
+__version__ = "0.4.6-dev"
 
 
 # register custom Part classes with opc package reader

--- a/docx/__init__.py
+++ b/docx/__init__.py
@@ -2,7 +2,7 @@
 
 from docx.api import Document  # noqa
 
-__version__ = "0.4.6-dev"
+__version__ = "0.4.6"
 
 
 # register custom Part classes with opc package reader

--- a/docx/oxml/simpletypes.py
+++ b/docx/oxml/simpletypes.py
@@ -215,7 +215,7 @@ class ST_Coordinate(BaseIntType):
     def convert_from_xml(cls, str_value):
         if 'i' in str_value or 'm' in str_value or 'p' in str_value:
             return ST_UniversalMeasure.convert_from_xml(str_value)
-        return Emu(int(str_value))
+        return Emu(int(round(float(str_value))))
 
     @classmethod
     def validate(cls, value):
@@ -280,7 +280,7 @@ class ST_HpsMeasure(XsdUnsignedLong):
     def convert_from_xml(cls, str_value):
         if 'm' in str_value or 'n' in str_value or 'p' in str_value:
             return ST_UniversalMeasure.convert_from_xml(str_value)
-        return Pt(int(str_value)/2.0)
+        return Pt(int(round(float(str_value)))/2.0)
 
     @classmethod
     def convert_to_xml(cls, value):
@@ -315,7 +315,7 @@ class ST_PositiveCoordinate(XsdLong):
 
     @classmethod
     def convert_from_xml(cls, str_value):
-        return Emu(int(str_value))
+        return Emu(int(round(float(str_value))))
 
     @classmethod
     def validate(cls, value):
@@ -332,7 +332,7 @@ class ST_SignedTwipsMeasure(XsdInt):
     def convert_from_xml(cls, str_value):
         if 'i' in str_value or 'm' in str_value or 'p' in str_value:
             return ST_UniversalMeasure.convert_from_xml(str_value)
-        return Twips(int(str_value))
+        return Twips(int(round(float(str_value))))
 
     @classmethod
     def convert_to_xml(cls, value):
@@ -375,7 +375,7 @@ class ST_TwipsMeasure(XsdUnsignedLong):
     def convert_from_xml(cls, str_value):
         if 'i' in str_value or 'm' in str_value or 'p' in str_value:
             return ST_UniversalMeasure.convert_from_xml(str_value)
-        return Twips(int(str_value))
+        return Twips(int(round(float(str_value))))
 
     @classmethod
     def convert_to_xml(cls, value):


### PR DESCRIPTION
# v0.4.6 (2023-05-26) CHANGELOG
* DEV-3195: wrap int() call in float() so we can read float vals of size attrs
    in e.g. w:spacing tags
---

Component PRs:

* #18 