### PR TITLE
DEV-4268: Fix namespace for Custom Properties

### DIFF
--- a/src/docx/__init__.py
+++ b/src/docx/__init__.py
@@ -13,7 +13,8 @@ from docx.api import Document
 if TYPE_CHECKING:
     from docx.opc.part import Part
 
-__version__ = "1.0.0"
+# __version__ = "1.0.1-a0"
+__version__ = "4268-rc0"
 
 
 __all__ = ["Document"]

--- a/src/docx/__init__.py
+++ b/src/docx/__init__.py
@@ -13,8 +13,7 @@ from docx.api import Document
 if TYPE_CHECKING:
     from docx.opc.part import Part
 
-# __version__ = "1.0.1-a0"
-__version__ = "4268-rc0"
+__version__ = "1.0.1-dev"
 
 
 __all__ = ["Document"]

--- a/src/docx/opc/customprops.py
+++ b/src/docx/opc/customprops.py
@@ -10,8 +10,7 @@ from __future__ import (
 
 import numbers
 from lxml import etree
-
-NS_VT = "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+from docx.oxml.ns import nspfxmap, qn
 
 
 class CustomProperties(object):
@@ -26,12 +25,12 @@ class CustomProperties(object):
         prop = self.lookup(item)
         if prop is not None:
             elm = prop[0]
-            if elm.tag == f"{{{NS_VT}}}i4":
+            if elm.tag == qn("vt:14"):
                 try:
                     return int(elm.text)
                 except ValueError:
                     return elm.text
-            elif elm.tag == f"{{{NS_VT}}}bool":
+            elif elm.tag == qn("vt:bool"):
                 return True if elm.text == '1' else False
             return elm.text
 
@@ -45,8 +44,8 @@ class CustomProperties(object):
             elif isinstance(value, numbers.Number):
                 elm_type = 'i4'
                 value = str(int(value))
-            prop = etree.SubElement(self._element, "property")
-            elm = etree.SubElement(prop, f"{{{NS_VT}}}{elm_type}", nsmap={'vt':NS_VT})
+            prop = etree.SubElement(self._element, qn("op:property"), nsmap=nspfxmap("op"))
+            elm = etree.SubElement(prop, qn(f"vt:{elm_type}"), nsmap=nspfxmap("vt"))
             elm.text = value
             prop.set("name", key)
             # magic number "FMTID_UserDefinedProperties"
@@ -55,9 +54,9 @@ class CustomProperties(object):
             prop.set("pid", str(len(self._element) + 1))
         else:
             elm = prop[0]
-            if elm.tag == f"{{{NS_VT}}}i4":
+            if elm.tag == qn("vt:i4"):
                 elm.text = str(int(value))
-            elif elm.tag == f"{{{NS_VT}}}bool":
+            elif elm.tag == qn("vt:bool"):
                 elm.text = str(1 if value else 0)
             else:
                 elm.text = str(value)

--- a/src/docx/opc/customprops.py
+++ b/src/docx/opc/customprops.py
@@ -25,7 +25,7 @@ class CustomProperties(object):
         prop = self.lookup(item)
         if prop is not None:
             elm = prop[0]
-            if elm.tag == qn("vt:14"):
+            if elm.tag == qn("vt:i4"):
                 try:
                     return int(elm.text)
                 except ValueError:

--- a/src/docx/oxml/__init__.py
+++ b/src/docx/oxml/__init__.py
@@ -90,7 +90,7 @@ register_element_cls("cp:coreProperties", CT_CoreProperties)
 
 from .customprops import CT_CustomProperties  # noqa
 
-register_element_cls('cup:Properties', CT_CustomProperties)
+register_element_cls('op:Properties', CT_CustomProperties)
 
 from .document import CT_Body, CT_Document  # noqa
 

--- a/src/docx/oxml/customprops.py
+++ b/src/docx/oxml/customprops.py
@@ -23,8 +23,8 @@ class CT_CustomProperties(BaseOxmlElement):
     part stored as ``/docProps/custom.xml``. String elements are
     limited in length to 255 unicode characters.
     """
-
-    _customProperties_tmpl = "<cup:Properties %s/>\n" % nsdecls("cup", "vt")
+    xmlns = 'xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties"'
+    _customProperties_tmpl = "<Properties %s/>\n" % (xmlns + " " + nsdecls("vt"))
     _offset_pattern = re.compile("([+-])(\\d\\d):(\\d\\d)")
 
     @classmethod

--- a/src/docx/oxml/customprops.py
+++ b/src/docx/oxml/customprops.py
@@ -16,21 +16,19 @@ from docx.oxml.xmlchemy import BaseOxmlElement
 from docx.oxml import parse_xml
 
 
-
 class CT_CustomProperties(BaseOxmlElement):
     """
     ``<Properties>`` element, the root element of the Custom Properties
     part stored as ``/docProps/custom.xml``. String elements are
     limited in length to 255 unicode characters.
     """
-    xmlns = 'xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties"'
-    _customProperties_tmpl = "<Properties %s/>\n" % (xmlns + " " + nsdecls("vt"))
+    _customProperties_tmpl = "<op:Properties %s/>\n" % nsdecls("op", "vt")
     _offset_pattern = re.compile("([+-])(\\d\\d):(\\d\\d)")
 
     @classmethod
     def new(cls):
         """
-        Return a new ``<property>`` element
+        Return a new ``<op:Properties>`` element
         """
         xml = cls._customProperties_tmpl
         custom_properties = parse_xml(xml)

--- a/src/docx/oxml/ns.py
+++ b/src/docx/oxml/ns.py
@@ -8,7 +8,7 @@ nsmap = {
     "a": "http://schemas.openxmlformats.org/drawingml/2006/main",
     "c": "http://schemas.openxmlformats.org/drawingml/2006/chart",
     "cp": "http://schemas.openxmlformats.org/package/2006/metadata/core-properties",
-    "cup": "http://schemas.openxmlformats.org/officeDocument/2006/custom-properties",
+    "op": "http://schemas.openxmlformats.org/officeDocument/2006/custom-properties",
     "dc": "http://purl.org/dc/elements/1.1/",
     "dcmitype": "http://purl.org/dc/dcmitype/",
     "dcterms": "http://purl.org/dc/terms/",


### PR DESCRIPTION
I originally thought this "Unreadable Content" warning had to do with the namespace prefix on the `Properties` tag: https://github.com/python-openxml/python-docx/pull/1273#issuecomment-2397916074

It did, in part, have to do with that. But in testing fixes, I thought that `op` was still wrong because:

1. I tried switching the nsprefix of `Properties` to `<op: Properties>` and still got the issue
2. Word creates `custom.xml` files without an nsprefix e.g. `<Properties>`

However, after using the [Open XML SDK Productivity Tool from dotnet](https://github.com/dotnet/Open-XML-SDK/releases/tag/v2.5) I was able to determine that the issue was from the missing namespace prefix on the child tag `<property>`

![image](https://github.com/user-attachments/assets/2902fe0e-d41a-45df-9c48-a008b606d312)

This PR changes the prefix to the correct one, `op` and adds the namespace prefix for all child elements `<op:property>`