### PR TITLE
v1.2.0: Support Serialization of python-docx/ lxml.Etree elements

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,6 +3,11 @@
 Release History
 ---------------
 
+X.Y.Z (YYYY-MM-DD)
+++++++++++++++++++
+
+
+
 1.1.0 (2025-03-25)
 ++++++++++++++++++
 - DEV-4646: add new color_val property to ``CT_RPr``

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,8 +3,9 @@
 Release History
 ---------------
 
-X.Y.Z (YYYY-MM-DD)
+1.2.0 (2025-05-22)
 ++++++++++++++++++
+- DEV-4746: Support Serialization of python-docx/ lxml.Etree elements
 
 
 

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -8,7 +8,6 @@ Release History
 - DEV-4746: Support Serialization of python-docx/ lxml.Etree elements
 
 
-
 1.1.0 (2025-03-25)
 ++++++++++++++++++
 - DEV-4646: add new color_val property to ``CT_RPr``

--- a/src/docx/__init__.py
+++ b/src/docx/__init__.py
@@ -13,7 +13,7 @@ from docx.api import Document
 if TYPE_CHECKING:
     from docx.opc.part import Part
 
-__version__ = "1.1.0"
+__version__ = "1.1.1-dev"
 
 
 __all__ = ["Document"]

--- a/src/docx/__init__.py
+++ b/src/docx/__init__.py
@@ -13,7 +13,7 @@ from docx.api import Document
 if TYPE_CHECKING:
     from docx.opc.part import Part
 
-__version__ = "4746-a0"
+__version__ = "1.2.0"
 
 
 __all__ = ["Document"]

--- a/src/docx/__init__.py
+++ b/src/docx/__init__.py
@@ -13,7 +13,7 @@ from docx.api import Document
 if TYPE_CHECKING:
     from docx.opc.part import Part
 
-__version__ = "1.1.1-dev"
+__version__ = "4746-a0"
 
 
 __all__ = ["Document"]

--- a/src/docx/shared.py
+++ b/src/docx/shared.py
@@ -142,6 +142,10 @@ class RGBColor(Tuple[int, int, int]):
         """Return a hex string rgb value, like '3C2F80'."""
         return "%02X%02X%02X" % self
 
+    def __reduce__(self):
+        # Return a tuple of (callable, args) that will recreate this object
+        return RGBColor, (self[0], self[1], self[2])
+
     @classmethod
     def from_string(cls, rgb_hex_str: str) -> RGBColor:
         """Return a new instance from an RGB color hex string like ``'3C2F80'``."""


### PR DESCRIPTION
`lxml.etree._Element` objects, and in turn `python-docx`'s `CT_`-type objects, are not pickle-able. 

This implementation adds support for very basic pickling of these objects. One very large caveat is that these elements, once unpickled, do not retain their relationships with other elements. They will only know about themselves and their children.

I have been using this branch locally for about two months and have had no issues.

ref. DEV-4746